### PR TITLE
Add -Label to New-BskyPost and -UserName to Get-BskyFeed

### DIFF
--- a/PSBlueSky.psm1
+++ b/PSBlueSky.psm1
@@ -53,8 +53,8 @@ Update-TypeData -TypeName 'PSBlueskySession' -MemberType ScriptProperty -MemberN
 Update-TypeData -TypeName 'PSBlueskySession' -MemberType ScriptMethod -MemberName Refresh -Value { Update-BskySession -RefreshToken $this.RefreshJwt } -Force
 
 Update-TypeData -TypeName 'PSBlueskySearchResult' -MemberType ScriptProperty -MemberName Age -Value { (Get-Date) - $this.Created } -Force
-Update-TypeData -TypeName 'PSBlueskyProfile' -MemberType ScriptProperty -MemberName Age -Value { (Get-Date) - $this.Created } -Force
-Update-TypeData -TypeName 'PSBlueskyFollowProfile' -MemberType ScriptProperty -MemberName Age -Value { (Get-Date) - $this.Created } -Force
+#Update-TypeData -TypeName 'PSBlueskyProfile' -MemberType ScriptProperty -MemberName Age -Value { (Get-Date) - $this.Created } -Force
+#Update-TypeData -TypeName 'PSBlueskyFollowProfile' -MemberType ScriptProperty -MemberName Age -Value { (Get-Date) - $this.Created } -Force
 #endregion
 
 #region verbose command highlighting

--- a/docs/Get-BskyFeed.md
+++ b/docs/Get-BskyFeed.md
@@ -77,6 +77,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -UserName
+
+Enter the profile or user name to get the feed from another user
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Profile
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/New-BskyPost.md
+++ b/docs/New-BskyPost.md
@@ -103,6 +103,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Label
+
+When posting an image it can be labeled as e.g. for 'sexual' for sexually suggestive but non-nude, 'nudity' for artistic / non-erotic nude, and 'porn' for adult content
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: false
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -Message
 
 The text of the post

--- a/functions/Get-PSBlueSkyPosts.ps1
+++ b/functions/Get-PSBlueSkyPosts.ps1
@@ -10,7 +10,11 @@ Function Get-BskyFeed {
     Param(
         [Parameter(HelpMessage = 'Enter the number of accounts that you follow to retrieve between 1 and 100. Default is 50.')]
         [ValidateRange(1, 100)]
-        [int]$Limit = 50
+        [int]$Limit = 50,
+
+        [ValidateNotNullOrEmpty()]
+        [Alias('Profile')]
+        [string]$UserName
     )
 
     Begin {
@@ -27,7 +31,9 @@ Function Get-BskyFeed {
         }
         if ($script:BSkySession.accessJwt) {
             $token = $script:BSkySession.accessJwt
-            $UserName = $script:BSkySession.handle
+            if (-not $PSBoundParameters.ContainsKey('UserName')) {
+                $UserName = $script:BSkySession.handle
+            }
             $did = $script:BskySession.did
             $headers = @{
                 Authorization  = "Bearer $token"
@@ -54,7 +60,12 @@ Function Get-BskyFeed {
         If ($headers) {
             _verbose -message ($strings.QueryFeed -f $limit, $Username)
             $filter = 'posts_with_replies'
-            $apiUrl = "$PDSHost/xrpc/app.bsky.feed.getAuthorFeed?actor=$did&limit=$Limit&filter=$filter"
+            if ($PSBoundParameters.ContainsKey('UserName')) {
+                $apiUrl = "$PDSHost/xrpc/app.bsky.feed.getAuthorFeed?actor=$UserName&limit=$Limit&filter=$filter"
+            }
+            else {
+                $apiUrl = "$PDSHost/xrpc/app.bsky.feed.getAuthorFeed?actor=$did&limit=$Limit&filter=$filter"
+            }
 
             _verbose $apiUrl
 

--- a/functions/Get-PSBlueSkyProfile.ps1
+++ b/functions/Get-PSBlueSkyProfile.ps1
@@ -63,23 +63,23 @@ Function Get-BskyProfile {
                     ErrorAction             = 'Stop'
                     ResponseHeadersVariable = 'rh'
                 }
-                $profile = Invoke-RestMethod @splat
+                $bSkyProfile = Invoke-RestMethod @splat
                 Write-Information -MessageData $rh -Tags ResponseHeader
-                If ($profile) {
-                    Write-Information -MessageData $profile -Tags raw
+                If ($bSkyProfile) {
+                    Write-Information -MessageData $bSkyProfile -Tags raw
                     [PSCustomObject]@{
                         PSTypeName  = 'PSBlueskyProfile'
-                        Username    = $profile.handle
-                        Display     = ($profile.displayName) ? $profile.displayName : $profile.handle
-                        Created     = $profile.createdAt.ToLocalTime()
-                        Description = $profile.description
-                        Avatar      = $profile.avatar
-                        Posts       = $profile.postsCount
-                        Followers   = $profile.followersCount
-                        Following   = $profile.followsCount
-                        Lists       = $profile.associated.lists
-                        URL         = "https://bsky.app/profile/$($profile.handle)"
-                        DID         = $profile.did
+                        Username    = $bSkyProfile.handle
+                        Display     = ($bSkyProfile.displayName) ? $bSkyProfile.displayName : $bSkyProfile.handle
+                        Created     = $bSkyProfile.createdAt.ToLocalTime()
+                        Description = $bSkyProfile.description
+                        Avatar      = $bSkyProfile.avatar
+                        Posts       = $bSkyProfile.postsCount
+                        Followers   = $bSkyProfile.followersCount
+                        Following   = $bSkyProfile.followsCount
+                        Lists       = $bSkyProfile.associated.lists
+                        URL         = "https://bsky.app/profile/$($bSkyProfile.handle)"
+                        DID         = $bSkyProfile.did
                     }
                 }
                 else {


### PR DESCRIPTION
As it says in the title, I've added the ability to label a post with a picture in it, and to get the feed for a user other than the current one.   (And updated the markdown help)
I also found a couple of cases where the code used variable name that PowerShell itself uses so I've renamed those. 
And finally I found when I reloaded the module the types.ps1xml file duplicated some lines in the the .psm1 so I've commented out the latter. That avoids an error on reloading the module. 

Cheers
James