### PR TITLE
Improvements to piping support for New posts

### DIFF
--- a/functions/New-PSBlueSkyPost.ps1
+++ b/functions/New-PSBlueSkyPost.ps1
@@ -22,8 +22,7 @@ Function New-BskyPost {
         [Alias('Alt')]
         [string]$ImageAlt,
         [Parameter(HelpMessage = 'Label for an image e.g. sexual,nudity,porn. The label length must be between 3 and 128 characters.', ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [ValidateLength(3,128)]
+        [AllowEmptyString()]
         [string]$Label
     )
 


### PR DESCRIPTION
Three small changes. 
1. When I put in the first PR I didn't allow the label column to be an empty string which breaks importing from a file
2. The import file I've been using had some control characters in it so I have add a line to strip out control chars, 
3. It also had some text that looked like a bluesky mention but wasn't `John Smith ( @johnsmith on Instagram)`is ok  `John Smith ( @john.smith on Instagram)` is looks like a bluesky user and gets an error on lookup, I've put that in a try catch block so it doesn't  to carry on creating the mention. 
 